### PR TITLE
Align text in action buttons to center

### DIFF
--- a/lib/src/elements/actions.dart
+++ b/lib/src/elements/actions.dart
@@ -176,7 +176,7 @@ class _AdaptiveActionSubmitState extends State<AdaptiveActionSubmit> with Adapti
     return RaisedButton(
       color: widget.color,
       onPressed: onTapped,
-      child: Text(title),
+      child: Text(title, textAlign: TextAlign.center),
     );
   }
 


### PR DESCRIPTION
This has only an effect on buttons with multiline text